### PR TITLE
Fix heap overflow in ip_reass on big packet input

### DIFF
--- a/slirp/ip_input.c
+++ b/slirp/ip_input.c
@@ -348,6 +348,8 @@ insert:
     q = fp->frag_link.next;
 	m = dtom(slirp, q);
 
+	int was_ext = m->m_flags & M_EXT;
+
 	q = (struct ipasfrag *) q->ipf_next;
 	while (q != (struct ipasfrag*)&fp->frag_link) {
 	  struct mbuf *t = dtom(slirp, q);
@@ -370,7 +372,7 @@ insert:
 	 * the old buffer (in the mbuf), so we must point ip
 	 * into the new buffer.
 	 */
-	if (m->m_flags & M_EXT) {
+	if (!was_ext && m->m_flags & M_EXT) {
 	  int delta = (char *)q - m->m_dat;
 	  q = (struct ipasfrag *)(m->m_ext + delta);
 	}


### PR DESCRIPTION
This PR fixes a potential security vulnerability in ip_reass() that was cloned from https://gitlab.freedesktop.org/slirp/libslirp but did not receive the security patch.

### Details:
Affected Function: ip_reass() in slirp/ip_input.c
Original Fix: https://gitlab.freedesktop.org/slirp/libslirp/-/commit/126c04acbabd7ad32c2b018fe10dfac2a3bc1210

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://gitlab.freedesktop.org/slirp/libslirp/-/commit/126c04acbabd7ad32c2b018fe10dfac2a3bc1210
- https://nvd.nist.gov/vuln/detail/cve-2019-14378
- 
Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
